### PR TITLE
Enforce writing specs when new rb files are created

### DIFF
--- a/spec/controllers/api/v1/api_controller_spec.rb
+++ b/spec/controllers/api/v1/api_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ApiController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/blocked_users_controller_spec.rb
+++ b/spec/controllers/api/v1/blocked_users_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::BlockedUsersController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/chats_controller_spec.rb
+++ b/spec/controllers/api/v1/chats_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ChatsController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/confirmations_controller_spec.rb
+++ b/spec/controllers/api/v1/confirmations_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ConfirmationsController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/likes_controller_spec.rb
+++ b/spec/controllers/api/v1/likes_controller_spec.rb
@@ -1,5 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::LikesController, type: :controller do
+  login_user
+  let(:user) { FactoryBot.create(:user, username: 'user1', email: 'user1@test.com') }
+
+  describe '#index' do
+    it "renders the index template" do
+      get :index, params: { page: 1 }
+      assert_response :success
+    end
+  end
+
+  describe '#create' do
+    context "when user is liked" do
+      before do
+        allow_any_instance_of(User).to receive(:voted_for?).with(user).and_return(true)
+      end
+      it "returns 422 status" do
+        put :create, params: {username: user.username}
+        assert_response :unprocessable_entity
+      end
+    end
+    context "when user is not yet liked" do
+      before do
+        allow_any_instance_of(User).to receive(:voted_for?).with(user).and_return(false)
+      end
+      it "returns 200 status" do
+        put :create, params: {username: user.username}
+        assert_response :success
+      end
+
+    end
+  end
 
 end

--- a/spec/controllers/api/v1/omniauths_controller_spec.rb
+++ b/spec/controllers/api/v1/omniauths_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::OmniauthsController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/passwords_controller_spec.rb
+++ b/spec/controllers/api/v1/passwords_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PasswordsController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/pictures_controller_spec.rb
+++ b/spec/controllers/api/v1/pictures_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PicturesController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/places_controller_spec.rb
+++ b/spec/controllers/api/v1/places_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PlacesController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/registrations_controller_spec.rb
+++ b/spec/controllers/api/v1/registrations_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::RegistrationsController, type: :controller do
+
+end

--- a/spec/controllers/api/v1/search_criteria_controller_spec.rb
+++ b/spec/controllers/api/v1/search_criteria_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::SearchCriteriaController, type: :controller do
+
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationJob do
+
+end

--- a/spec/jobs/message_broadcast_job_spec.rb
+++ b/spec/jobs/message_broadcast_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationJob::MessageBroadcastJob do
+
+end

--- a/spec/jobs/messages_notifications_broadcast_job_spec.rb
+++ b/spec/jobs/messages_notifications_broadcast_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationJob::MessagesNotificationsBroadcastJob do
+
+end

--- a/spec/lib/api_constraints_spec.rb
+++ b/spec/lib/api_constraints_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ApiConstraints do
+
+end

--- a/spec/lib/notifications/base_spec.rb
+++ b/spec/lib/notifications/base_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Notifications::Base do
+
+end

--- a/spec/lib/notifications/hearts_spec.rb
+++ b/spec/lib/notifications/hearts_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Notifications::Hearts do
+
+end

--- a/spec/lib/personalities/answer_validator_spec.rb
+++ b/spec/lib/personalities/answer_validator_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Personalities::AnswerValidator do
+
+end

--- a/spec/lib/personalities/test_spec.rb
+++ b/spec/lib/personalities/test_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Personalities::Test do
+
+end

--- a/spec/lib/queries/base_spec.rb
+++ b/spec/lib/queries/base_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Queries::Base do
+
+end

--- a/spec/lib/queries/builder_spec.rb
+++ b/spec/lib/queries/builder_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Queries::Builder do
+
+end

--- a/spec/lib/recaptcha/client_spec.rb
+++ b/spec/lib/recaptcha/client_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Recaptcha::Client do
+
+end

--- a/spec/lib/search_criteria_calculator_spec.rb
+++ b/spec/lib/search_criteria_calculator_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe SearchCriteriaCalculator do
+
+end
+

--- a/spec/lib/services/conversations_spec.rb
+++ b/spec/lib/services/conversations_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Services::Conversations do
+
+end

--- a/spec/lib/services/likes_spec.rb
+++ b/spec/lib/services/likes_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Services::Likes do
+
+end

--- a/spec/lib/services/user_blocked_check_spec.rb
+++ b/spec/lib/services/user_blocked_check_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Services::UserBlockedCheck do
+
+end

--- a/spec/test_suite_spec.rb
+++ b/spec/test_suite_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_support/core_ext/string/inflections"
+
+RSpec.describe "TestSuite" do
+  Dir["{app}/**/*.rb", "engines/**/{app}/**/*.rb"].each do |filename|
+    context filename do
+      subject { filename }
+
+      let(:testfile) do
+        filename
+            .sub("app", "spec")
+            .sub(".rb", "_spec.rb")
+      end
+
+      it "fails when file has no tests" do
+        next if testfile =~ /models\/.+_spec.rb/ # Very few models require testing, so not to create "it exists"...
+        next if testfile =~ /mailers\/.+_spec.rb/ # Ignore mailers
+        next if testfile =~ /serializers\/.+_spec.rb/ # Ignore serializers
+        next if testfile =~ /policies\/.+_spec.rb/ # Ignore policies
+        next if testfile =~ /channels\/.+_spec.rb/ # Ignore channels
+
+
+        expect(File.exist?(testfile)).to be_truthy, "File `#{testfile}` must exist"
+        class_name = File.basename(filename, ".rb").camelcase
+        File.open(testfile, :encoding => "utf-8") do |file|
+          expect(file.read.downcase).to match(class_name.downcase)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There were no issue for this PR, but now every time somebody creates a new RB file it forces them to write spec for it.

Together with `simplecov` gem it will allow you to maintain high % test coverage!
